### PR TITLE
Modified loader and libc usage in template.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,19 @@ ld = ELF("./ld-2.23.so")
 
 context.binary = exe
 
+env = dict(LD_PRELOAD="%s:%s" % (ld.path, libc.path))
 
 def conn():
-    if args.LOCAL:
-        return process([ld.path, exe.path], env={"LD_PRELOAD": libc.path})
-    else:
+    if args.GDB:
+        return gdb.debug(exe.path, env=env, gdbscript=gdbscript)
+    elif args.REMOTE:
         return remote("addr", 1337)
+    else:
+        return process(exe.path, env=env)
 
+gdbscript = """
+continue
+"""
 
 def main():
     r = conn()

--- a/src/template.py
+++ b/src/template.py
@@ -6,13 +6,19 @@ from pwn import *
 
 context.binary = {bin_name}
 
+env = dict(LD_PRELOAD="%s:%s" % (ld.path, libc.path))
 
 def conn():
-    if args.LOCAL:
-        return process({proc_args})
-    else:
+    if args.GDB:
+        return gdb.debug(exe.path, env=env, gdbscript=gdbscript)
+    elif args.REMOTE:
         return remote("addr", 1337)
+    else:
+        return process(exe.path, env=env)
 
+gdbscript = """
+continue
+"""
 
 def main():
     r = conn()


### PR DESCRIPTION
Instead of running the binary with the loader, the loader is included in **LD_PRELOAD**. Thanks to this, we can run gdb.debug, which was not easily possible in the previous template.

The binary will run like so:
```
LD_PRELOAD=./ld-2.24.so:./libc.so.6 ./binary
```