### PR TITLE
Fix argument for enabling GDB in template.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ context.binary = exe
 def conn():
     if args.LOCAL:
         r = process([exe.path])
-        if args.DEBUG:
+        if args.GDB:
             gdb.attach(r)
     else:
         r = remote("addr", 1337)

--- a/src/template.py
+++ b/src/template.py
@@ -10,7 +10,7 @@ context.binary = {bin_name}
 def conn():
     if args.LOCAL:
         r = process({proc_args})
-        if args.DEBUG:
+        if args.GDB:
             gdb.attach(r)
     else:
         r = remote("addr", 1337)


### PR DESCRIPTION
The `DEBUG` argument doesn't work here because it is reserved by pwntools for turning on its debugging output and pwntools does not expose reserved arguments in `args`. This commit changes the argument name to `GDB` so that it does not conflict with a reserved argument.