### PR TITLE
Adding basic vmlinux identification & extraction

### DIFF
--- a/src/proc_vmlinux.rs
+++ b/src/proc_vmlinux.rs
@@ -1,0 +1,80 @@
+use crate::opts::Opts;
+
+use std::path::Path;
+use std::process::Command;
+
+use colored::Colorize;
+use snafu::ResultExt;
+use snafu::Snafu;
+use std::fs::File;
+
+use std::io;
+
+#[derive(Debug, Snafu)]
+#[allow(clippy::enum_variant_names)]
+pub enum Error {
+    #[snafu(display("extract-vmlinux failed with nonzero exit status"))]
+    ExtractVmlinux,
+
+    #[snafu(display("extract-vmlinux failed to start; install it as shown in README.md"))]
+    ExtractVmlinuxExec { source: io::Error },
+    
+    #[snafu(display("vmlinux-to-elf failed to start; install it as shown in README.md"))]
+    VmlinuxToElfExec { source: io::Error },
+
+    #[snafu(display("vmlinux-to-elf failed with nonzero exit status"))]
+    VmlinuxToElf,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+fn run_extract_vmlinux(bzimage: &Path) -> Result<()> {
+    println!(
+        "{}",
+        format!("running extract-vmlinux on {}", bzimage.to_string_lossy().bold()).green()
+    );
+
+    let mut cmd = Command::new("extract-vmlinux");
+    let new_vmlinux_file = File::create("./vmlinux").unwrap();
+    cmd.arg(bzimage).stdout(std::process::Stdio::from(new_vmlinux_file));
+    let status = cmd.status().context(ExtractVmlinuxExecSnafu)?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::ExtractVmlinux)
+    }
+}
+
+fn run_vmlinux_to_elf(vmlinux: &Path) -> Result<()> {
+    println!(
+        "{}", 
+        format!("running vmlinux-to-elf on {}", vmlinux.to_string_lossy().bold()).green()
+    );
+
+    let mut cmd = Command::new("vmlinux-to-elf");
+    cmd
+        .arg(vmlinux)
+        .arg(format!("{}_patched", vmlinux.to_string_lossy()));
+    let status = cmd.status().context(VmlinuxToElfExecSnafu)?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::VmlinuxToElf)
+    }
+}
+
+pub fn extract_vmlinux_from_bzimage(opts: &Opts) -> Result<()> {
+    if let Some(bzimage) = &opts.bzimage { 
+        run_extract_vmlinux(bzimage)?;
+    }
+
+    Ok(())
+}
+
+pub fn patch_vmlinux(opts: &Opts) -> Result<()> {
+    if let Some(vmlinux) = &opts.vmlinux {
+        run_vmlinux_to_elf(vmlinux)?;
+    }
+
+    Ok(())
+}

--- a/src/pwninit.rs
+++ b/src/pwninit.rs
@@ -3,8 +3,10 @@ use crate::opts;
 use crate::patch_bin;
 use crate::set_bin_exec;
 use crate::set_ld_exec;
+use crate::set_vmlinux_exec;
 use crate::solvepy;
 use crate::Opts;
+use crate::proc_vmlinux;
 
 use ex::io;
 use snafu::ResultExt;
@@ -28,6 +30,15 @@ pub enum Error {
 
     #[snafu(display("failed making template solve script: {}", source))]
     Solvepy { source: solvepy::Error },
+
+    #[snafu(display("failed extracting vmlinux: {}", source))]
+    ExtractVmlinux { source: proc_vmlinux::Error },
+
+    #[snafu(display("failed setting vmlinux executable: {}", source))]
+    SetVmlinuxExec { source: io::Error },
+
+    #[snafu(display("failed patching vmlinux: {}", source))]
+    PatchVmlinux { source: proc_vmlinux::Error },
 }
 
 pub type Result = std::result::Result<(), Error>;
@@ -41,20 +52,35 @@ pub fn run(opts: Opts) -> Result {
     opts.print();
     println!();
 
-    set_bin_exec(&opts).context(SetBinExecSnafu)?;
-    maybe_visit_libc(&opts);
+    if opts.ker {
+        if !opts.no_extract_vmlinux {
+            proc_vmlinux::extract_vmlinux_from_bzimage(&opts).context(ExtractVmlinuxSnafu)?;
+        }
 
-    // Redo detection in case the ld was downloaded
-    let opts = opts.find_if_unspec().context(FindSnafu)?;
+        // Redo detection in case the vmlinux was extracted
+        let opts = opts.find_if_unspec().context(FindSnafu)?;
 
-    set_ld_exec(&opts).context(SetLdExecSnafu)?;
+        if !opts.no_patch_vmlinux {
+            proc_vmlinux::patch_vmlinux(&opts).context(PatchVmlinuxSnafu)?;
+        }
 
-    if !opts.no_patch_bin {
-        patch_bin::patch_bin(&opts).context(PatchBinSnafu)?;
-    }
+        set_vmlinux_exec(&opts).context(SetVmlinuxExecSnafu)?;
+    } else {
+        set_bin_exec(&opts).context(SetBinExecSnafu)?;
+        maybe_visit_libc(&opts);
 
-    if !opts.no_template {
-        solvepy::write_stub(&opts).context(SolvepySnafu)?;
+        // Redo detection in case the ld was downloaded
+        let opts = opts.find_if_unspec().context(FindSnafu)?;
+
+        set_ld_exec(&opts).context(SetLdExecSnafu)?;
+
+        if !opts.no_patch_bin {
+            patch_bin::patch_bin(&opts).context(PatchBinSnafu)?;
+        }
+
+        if !opts.no_template {
+            solvepy::write_stub(&opts).context(SolvepySnafu)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Right now it works if shell commands `vmlinux-to-elf [file] [outfile]` and `extract-vmlinux [file] > [outfile]` works. 

We need to discuss how to add the vmlinux-to-elf and extract-vmlinux dependencies since they both are non-rust, so can't just append into `cargo.toml`.

* `vmlinux-to-elf` is a [github repository](https://github.com/marin-m/vmlinux-to-elf) 
* extract-vmlinux is just a bash script provided in any linux source(does not depend on kernel version).

We can make it 2 ways: 
* add custom initialization (post-cargo). Like "install.sh" and implement installation there
* just show in `README.md` how to install them both.

What do you prefer?