### PR TITLE
Add option to disable unstripping libc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@ fn visit_libc(opts: &Opts, libc: &Path) {
         }
     };
     maybe_fetch_ld(opts, &ver).warn("failed fetching ld");
-    unstrip_libc(libc, &ver).warn("failed unstripping libc");
+
+    if !opts.no_unstrip_libc {
+        unstrip_libc(libc, &ver).warn("failed unstripping libc");
+    }
 }
 
 /// Same as `visit_libc()`, but doesn't do anything if no libc is found

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -75,6 +75,10 @@ pub struct Opts {
     #[structopt(long)]
     pub no_patch_bin: bool,
 
+    /// Disable unstripping the libc
+    #[structopt(long)]
+    pub no_unstrip_libc: bool,
+
     /// Disable generating template solve script
     #[structopt(long)]
     pub no_template: bool,


### PR DESCRIPTION
Sometimes when doing relatively simple challenges under bad internet connection, unstripping libc can be extremely slow. 
This commit allows the user to disable unstripping libc when needed. 