### PR TITLE
Remove binary patching when there is no libc

### DIFF
--- a/src/patch_bin.rs
+++ b/src/patch_bin.rs
@@ -125,7 +125,7 @@ fn bin_patched_path_from_bin(bin: &Path) -> Result<PathBuf> {
 
 /// Add "_patched" to the end of the binary file name if the binary got patched.
 pub fn bin_patched_path(opts: &Opts) -> Option<PathBuf> {
-    match opts.no_patch_bin {
+    match opts.no_patch_bin || opts.libc.is_none() {
         true => None,
         false => opts
             .bin

--- a/src/pwninit.rs
+++ b/src/pwninit.rs
@@ -49,7 +49,7 @@ pub fn run(opts: Opts) -> Result {
 
     set_ld_exec(&opts).context(SetLdExecSnafu)?;
 
-    if !opts.no_patch_bin {
+    if !opts.no_patch_bin && opts.libc.is_some() {
         patch_bin::patch_bin(&opts).context(PatchBinSnafu)?;
     }
 


### PR DESCRIPTION
This checks for the presence of libc before performing any patching, preventing the generation of an unnecessary _patched binary when there is no libc.